### PR TITLE
Added unixodbc to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && \
     # Postgres client
     libpq-dev \
     # ODBC support:
-    g++ unixodbc-dev \
+    g++ unixodbc-dev unixodbc \
     # for SAML
     xmlsec1 \
     # Additional packages required for data sources:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

I was getting errors when installing on an old Ubutnu 16.04 machine
```
The following packages have unmet dependencies:
 unixodbc : Depends: odbcinst1debian2 (>= 2.3.7) but 2.3.6-0.1build1 is to be installed
            Depends: libodbc1 (>= 2.3.7) but 2.3.6-0.1build1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

and found that the version on MS's servers is too new for me (2.3.7), but adding the Debian served one FIRST (2.3.6) fixed the issue for me, following this advice https://stackoverflow.com/a/63187951.

Not sure if it's worth fixing for everyone but seems pretty safe.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
